### PR TITLE
Updates `run` so it can support jest-cli promise

### DIFF
--- a/src/tools/runner.js
+++ b/src/tools/runner.js
@@ -121,15 +121,7 @@ class JestExRunner {
   */
   run() {
     const config = this._getFormattedConfig();
-    return new Promise((resolve, reject) => {
-      jestCLI.runCLI(config, [config.rootDir], (success) => {
-        if (success) {
-          resolve();
-        } else {
-          reject();
-        }
-      });
-    });
+    return jestCLI.runCLI(config, [config.rootDir]);
   }
   /**
   * Inject the path of the Jest-Ex Transformer to the Jest configuration. The transformer only


### PR DESCRIPTION
### What does this PR do?

Fixes the promise implementation for the CLI runner, because the new version of jest returns a promise instead of using callbacks since v21.0.0 (Sept. 4, 2017).

### How should it be tested manually?

- Configure JestExRunner promises: `JestExRunner(..., ...).run().then(/* success */).catch(/* error */);`
- Run JestExRunner against, at least, one broken test
- Make sure the `catch` is called

---

![](https://m.popkey.co/0ab04c/AVGgm.gif)
